### PR TITLE
Revamped differential

### DIFF
--- a/src/main/java/com/petrolpark/petrolsparts/content/kinetics/differential/DifferentialBlock.java
+++ b/src/main/java/com/petrolpark/petrolsparts/content/kinetics/differential/DifferentialBlock.java
@@ -2,13 +2,10 @@ package com.petrolpark.petrolsparts.content.kinetics.differential;
 
 import com.petrolpark.compat.create.core.block.entity.behaviour.AbstractRememberPlacerBehaviour;
 import com.petrolpark.petrolsparts.PetrolsPartsBlockEntityTypes;
-import com.petrolpark.petrolsparts.PetrolsPartsBlocks;
-import com.petrolpark.petrolsparts.core.advancement.PetrolsPartsAdvancementBehaviour;
 import com.petrolpark.petrolsparts.core.block.DirectionalRotatedPillarKineticBlock;
 import com.petrolpark.util.KineticsHelper;
 import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
 import com.simibubi.create.content.kinetics.simpleRelays.CogWheelBlock;
-import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -22,7 +19,6 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition.Builder;
@@ -73,30 +69,26 @@ public class DifferentialBlock extends CogWheelBlock {
     @SuppressWarnings("null")
     public void onNeighborChange(BlockState state, LevelReader level, BlockPos pos, BlockPos neighbor) {
         withBlockEntityDo(level, pos, be -> {
-            BlockEntity neighborBE = level.getBlockEntity(neighbor);
-            Direction directionBetween = KineticsHelper.directionBetween(pos, neighbor);
-            Direction differentialDirection = DirectionalRotatedPillarKineticBlock.getDirection(state);
-            if (be instanceof DifferentialBlockEntity differential && differential.hasLevel() && directionBetween == differentialDirection.getOpposite()) {
-                float newControlSpeed = 0f;
-                if (neighborBE instanceof KineticBlockEntity kbe) newControlSpeed = differential.getPropagatedSpeed(kbe, differentialDirection);
-                if (differential.oldControlSpeed != newControlSpeed) {
-                    differential.getLevel().scheduleTick(pos, this, 1);
-                };
-            };
+            if (!(be instanceof DifferentialBlockEntity diff) || !diff.hasLevel()) return;
+            Direction face = DirectionalRotatedPillarKineticBlock.getDirection(state);
+            Direction between = KineticsHelper.directionBetween(pos, neighbor);
+            if (between == face || between == face.getOpposite()) {
+                diff.updateGeneratedRotation();
+            }
         });
         super.onNeighborChange(state, level, pos, neighbor);
     };
 
     @Override
     public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
-        level.setBlockAndUpdate(pos, PetrolsPartsBlocks.DUMMY_DIFFERENTIAL.getDefaultState().setValue(AXIS, state.getValue(AXIS)).setValue(DirectionalRotatedPillarKineticBlock.POSITIVE_AXIS_DIRECTION, state.getValue(DirectionalRotatedPillarKineticBlock.POSITIVE_AXIS_DIRECTION))); // It thinks getLevel() might be null
-        PetrolsPartsAdvancementBehaviour behaviour = BlockEntityBehaviour.get(level, pos, PetrolsPartsAdvancementBehaviour.TYPE);
-        AbstractRememberPlacerBehaviour.setPlacedBy(level, pos, behaviour.getPlayer());
+        withBlockEntityDo(level, pos, be -> {
+            if (be instanceof DifferentialBlockEntity diff) diff.updateGeneratedRotation();
+        });
     };
 
     @Override
     public boolean hasShaftTowards(LevelReader world, BlockPos pos, BlockState state, Direction face) {
-        return face == DirectionalRotatedPillarKineticBlock.getDirection(state);
+        return false;
     };
 
     @Override
@@ -110,7 +102,7 @@ public class DifferentialBlock extends CogWheelBlock {
     };
 
     @Override
-	public BlockEntityType<? extends KineticBlockEntity> getBlockEntityType() {
+    public BlockEntityType<? extends KineticBlockEntity> getBlockEntityType() {
         return PetrolsPartsBlockEntityTypes.DIFFERENTIAL.get();
     };
 
@@ -118,5 +110,5 @@ public class DifferentialBlock extends CogWheelBlock {
     public Axis getRotationAxis(BlockState state) {
         return state.getValue(AXIS);
     };
-    
+
 };

--- a/src/main/java/com/petrolpark/petrolsparts/content/kinetics/differential/DifferentialBlockEntity.java
+++ b/src/main/java/com/petrolpark/petrolsparts/content/kinetics/differential/DifferentialBlockEntity.java
@@ -1,33 +1,36 @@
 package com.petrolpark.petrolsparts.content.kinetics.differential;
 
 import java.util.List;
+import java.util.Objects;
 
-import com.petrolpark.compat.create.core.block.entity.behaviour.AbstractRememberPlacerBehaviour;
-import com.petrolpark.petrolsparts.PetrolsPartsBlocks;
-import com.petrolpark.petrolsparts.content.kinetics.coaxialGear.LongShaftBlockEntity;
 import com.petrolpark.petrolsparts.core.advancement.PetrolsPartsAdvancementBehaviour;
 import com.petrolpark.petrolsparts.core.advancement.PetrolsPartsAdvancementTriggers;
 import com.petrolpark.petrolsparts.core.block.DirectionalRotatedPillarKineticBlock;
-import com.petrolpark.petrolsparts.mixin.accessor.RotationPropagatorAccessor;
 import com.petrolpark.util.KineticsHelper;
+import com.simibubi.create.content.kinetics.KineticNetwork;
+import com.simibubi.create.content.kinetics.base.GeneratingKineticBlockEntity;
 import com.simibubi.create.content.kinetics.base.IRotate;
 import com.simibubi.create.content.kinetics.base.KineticBlock;
 import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
-import com.simibubi.create.content.kinetics.transmission.SplitShaftBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.Direction.AxisDirection;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 
-public class DifferentialBlockEntity extends SplitShaftBlockEntity {
+import javax.annotation.Nullable;
+
+public class DifferentialBlockEntity extends GeneratingKineticBlockEntity {
 
     public PetrolsPartsAdvancementBehaviour advancementBehaviour;
-    public float oldControlSpeed;
+
+    private DifferentialSink inputSink;
+    private DifferentialSink controlSink;
+    private Long lastInputNetwork = null;
+    private Long lastControlNetwork = null;
 
     public DifferentialBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -41,79 +44,221 @@ public class DifferentialBlockEntity extends SplitShaftBlockEntity {
     };
 
     @Override
-    public float propagateRotationTo(KineticBlockEntity target, BlockState stateFrom, BlockState stateTo, BlockPos diff, boolean connectedViaAxes, boolean connectedViaCogs) {
-        if (connectedViaAxes || LongShaftBlockEntity.connectedToLongShaft(this, target, diff)) {
-            if (target instanceof DifferentialBlockEntity) return 0f;
-            return ratio(stateFrom) * Math.signum(RotationPropagatorAccessor.invokeGetAxisModifier(target, KineticsHelper.directionBetween(target.getBlockPos(), getBlockPos())));
-        };
-        return super.propagateRotationTo(target, stateFrom, stateTo, diff, connectedViaAxes, connectedViaCogs);
-	};
-
-    @Override
-    @SuppressWarnings("null") // It thinks getLevel() might be null
-    public void setSource(BlockPos source) {
-        super.setSource(source);
-        Direction directionBetween = KineticsHelper.directionBetween(getBlockPos(), source);
-        if (hasLevel() && (directionBetween == null || directionBetween.getAxis() != getBlockState().getValue(DifferentialBlock.AXIS))) getLevel().destroyBlock(getBlockPos(), true);
+    public void onLoad() {
+        super.onLoad();
+        if (!level.isClientSide) {
+            inputSink = new DifferentialSink(this);
+            controlSink = new DifferentialSink(this);
+        }
     };
 
     @Override
-    @SuppressWarnings("null") // It thinks getLevel() might be null
+    public float calculateAddedStressCapacity() {
+        if (!hasLevel() || speed == 0f) return 0f;
+
+        Direction face = DirectionalRotatedPillarKineticBlock.getDirection(getBlockState());
+        KineticBlockEntity kbeA = getAdjacentKBE(getBlockPos().relative(face), face.getOpposite());
+        KineticBlockEntity kbeB = getAdjacentKBE(getBlockPos().relative(face.getOpposite()), face);
+        float absA = kbeA != null ? Math.abs(getPropagatedSpeed(kbeA, face.getOpposite())) : 0f;
+        float absB = kbeB != null ? Math.abs(getPropagatedSpeed(kbeB, face)) : 0f;
+
+        float capacityA = absA > 0f ? getNetworkCapacity(inputSink, lastInputNetwork) : 0f;
+        float capacityB = absB > 0f
+                ? (Objects.equals(lastInputNetwork, lastControlNetwork) ? 0f : getNetworkCapacity(controlSink, lastControlNetwork))
+                : 0f;
+        float coefficient = (capacityA + capacityB) / Math.abs(speed);
+        this.lastCapacityProvided = coefficient;
+        return coefficient;
+    };
+
+    /**
+     * Returns the current capacity (in SU) of the KineticNetwork identified by {@code networkId}.
+     * Reads directly from the network object (no per-tick caching lag) via {@link KineticNetworkAccessor}.
+     */
+    private float getNetworkCapacity(DifferentialSink sink, Long networkId) {
+        if (sink == null || networkId == null) return 0f;
+        Long previous = sink.network;
+        sink.network = networkId;
+        KineticNetwork net = sink.getOrCreateNetwork();
+        sink.network = previous;
+        if (net == null) return 0f;
+        return ((com.petrolpark.petrolsparts.mixin.accessor.KineticNetworkAccessor) net).getCurrentCapacity();
+    };
+
+    /**
+     * Returns the current stress (in SU) of the KineticNetwork identified by {@code networkId}.
+     */
+    private float getNetworkStress(DifferentialSink sink, Long networkId) {
+        if (sink == null || networkId == null) return 0f;
+        Long previous = sink.network;
+        sink.network = networkId;
+        KineticNetwork net = sink.getOrCreateNetwork();
+        sink.network = previous;
+        if (net == null) return 0f;
+        return ((com.petrolpark.petrolsparts.mixin.accessor.KineticNetworkAccessor) net).getCurrentStress();
+    };
+
+    @Override
+    public float getGeneratedSpeed() {
+        if (!hasLevel()) return 0f;
+        Direction face = DirectionalRotatedPillarKineticBlock.getDirection(getBlockState());
+        BlockPos sideAPos = getBlockPos().relative(face);
+        BlockPos sideBPos = getBlockPos().relative(face.getOpposite());
+        float speedA = 0f, speedB = 0f;
+        BlockEntity beA = level.getBlockEntity(sideAPos);
+        BlockEntity beB = level.getBlockEntity(sideBPos);
+        if (propagatesToMe(sideAPos, face.getOpposite()) && beA instanceof KineticBlockEntity kbeA)
+            speedA = getPropagatedSpeed(kbeA, face.getOpposite());
+        if (propagatesToMe(sideBPos, face) && beB instanceof KineticBlockEntity kbeB)
+            speedB = getPropagatedSpeed(kbeB, face);
+        return (speedA + speedB) / 2f;
+    };
+
+    @Override
+    @SuppressWarnings("null")
     public void tick() {
         super.tick();
-        if (!hasLevel()) return;
+        if (level.isClientSide || inputSink == null) return;
 
-        Direction direction = DirectionalRotatedPillarKineticBlock.getDirection(getBlockState());
-        BlockPos otherAdjacentPos = getBlockPos().relative(direction.getOpposite());
+        Direction face = DirectionalRotatedPillarKineticBlock.getDirection(getBlockState());
+        BlockPos sideAPos = getBlockPos().relative(face);
+        BlockPos sideBPos = getBlockPos().relative(face.getOpposite());
+        KineticBlockEntity kbeA = getAdjacentKBE(sideAPos, face.getOpposite());
+        KineticBlockEntity kbeB = getAdjacentKBE(sideBPos, face);
 
-        if (getSpeed() == 0f) { // Try switching the direction if we're not powered by the existing side
-            BlockPos adjacentPos = getBlockPos().relative(direction);
-            if (!propagatesToMe(adjacentPos, direction.getOpposite()) && propagatesToMe(otherAdjacentPos, direction)) {
-                getLevel().setBlockAndUpdate(getBlockPos(), PetrolsPartsBlocks.DUMMY_DIFFERENTIAL.getDefaultState().setValue(DifferentialBlock.AXIS, direction.getAxis()).setValue(DirectionalRotatedPillarKineticBlock.POSITIVE_AXIS_DIRECTION, direction.getAxisDirection() == AxisDirection.NEGATIVE)); 
-                AbstractRememberPlacerBehaviour.setPlacedBy(level, getBlockPos(), advancementBehaviour.getPlayer());
-            };
-        };
+        float newSpeed = getGeneratedSpeed();
+        if (newSpeed != speed) updateGeneratedRotation();
+        Long netA = kbeA != null ? kbeA.network : null;
+        Long netB = kbeB != null ? kbeB.network : null;
 
-        if (getLevel().getBlockEntity(otherAdjacentPos) instanceof KineticBlockEntity kbe) {
-            oldControlSpeed = getPropagatedSpeed(kbe, direction);
-        };
+        if (!Objects.equals(netA, lastInputNetwork)) {
+            removeSink(inputSink, lastInputNetwork);
+            injectSink(inputSink, netA);
+            lastInputNetwork = netA;
+        }
+        if (!Objects.equals(netB, lastControlNetwork)) {
+            removeSink(controlSink, lastControlNetwork);
+            injectSink(controlSink, netB);
+            lastControlNetwork = netB;
+        }
+
+        // Proportional split with capacity-aware redistribution:
+        // Each side's requested share is proportional to its speed contribution.
+        // If one network is at capacity, clamp it to its available headroom and
+        // push the remainder to the other side. If neither network can absorb the full
+        // demand, both become overstressed
+        float absA = kbeA != null ? Math.abs(getPropagatedSpeed(kbeA, face.getOpposite())) : 0f;
+        float absB = kbeB != null ? Math.abs(getPropagatedSpeed(kbeB, face)) : 0f;
+        float totalAbs = absA + absB;
+        float totalDemand = this.stress;
+
+        float requestedA = totalAbs > 0f ? totalDemand * (absA / totalAbs) : totalDemand * 0.5f;
+        float requestedB = totalAbs > 0f ? totalDemand * (absB / totalAbs) : totalDemand * 0.5f;
+
+        // Available headroom on each input network.
+        float capacityA = absA > 0f ? getNetworkCapacity(inputSink, lastInputNetwork) : 0f;
+        float stressA   = absA > 0f ? getNetworkStress(inputSink, lastInputNetwork)   : 0f;
+        float capacityB = absB > 0f ? getNetworkCapacity(controlSink, lastControlNetwork) : 0f;
+        float stressB   = absB > 0f ? getNetworkStress(controlSink, lastControlNetwork)   : 0f;
+        float sinkOwnDrawA = inputSink  != null ? inputSink.getStressImpact()  : 0f;
+        float sinkOwnDrawB = controlSink != null ? controlSink.getStressImpact() : 0f;
+        float headroomA = absA > 0f ? Math.max(0f, capacityA - (stressA - sinkOwnDrawA)) : 0f;
+        float headroomB = absB > 0f ? Math.max(0f, capacityB - (stressB - sinkOwnDrawB)) : 0f;
+
+        float allocA = distributeStress(requestedA, requestedB, headroomA, headroomB)[0];
+        float allocB = distributeStress(requestedA, requestedB, headroomA, headroomB)[1];
+
+        updateSinkStress(inputSink,   lastInputNetwork,   allocA);
+        updateSinkStress(controlSink, lastControlNetwork, allocB);
+    };
+
+    @Nullable
+    private KineticBlockEntity getAdjacentKBE(BlockPos pos, Direction directionToMe) {
+        if (!propagatesToMe(pos, directionToMe)) return null;
+        BlockEntity be = level.getBlockEntity(pos);
+        return be instanceof KineticBlockEntity kbe ? kbe : null;
+    };
+
+    private void injectSink(DifferentialSink sink, Long networkId) {
+        if (networkId == null) return;
+        sink.network = networkId;
+        KineticNetwork net = sink.getOrCreateNetwork();
+        if (net == null) { sink.network = null; return; }
+        boolean alreadyPresent = net.members.containsKey(sink);
+        if (!alreadyPresent) net.members.put(sink, 0f);
+        net.updateStress();
+    };
+
+    private void removeSink(DifferentialSink sink, Long networkId) {
+        if (sink == null || networkId == null) return;
+        sink.network = networkId;
+        KineticNetwork net = sink.getOrCreateNetwork();
+        if (net != null) {
+            net.members.remove(sink);
+            net.sources.remove(sink);
+            net.updateStress();
+        }
+        sink.network = null;
+    };
+
+    private void updateSinkStress(DifferentialSink sink, Long networkId, float absoluteSU) {
+        if (networkId == null || sink.network == null) return;
+        sink.setStressImpact(absoluteSU);
+        KineticNetwork net = sink.getOrCreateNetwork();
+        // updateStressFor: members.put(sink, absoluteSU) + updateStress()
+        // KineticNetworkMixin bypasses identity-check eviction for DifferentialSink
+        if (net != null) net.updateStressFor(sink, absoluteSU);
+    };
+
+    private float[] distributeStress(float requestedA, float requestedB, float headroomA, float headroomB) {
+        float allocA = requestedA;
+        float allocB = requestedB;
+
+        if (allocA > headroomA) {
+            float spill = allocA - headroomA;
+            allocA = headroomA;
+            allocB += spill;
+        }
+
+        if (allocB > headroomB) {
+            float spill = allocB - headroomB;
+            allocB = headroomB;
+            allocA += spill;
+
+            if (allocA > headroomA && allocA - headroomA < 1f) {
+                allocA = headroomA;
+            }
+        }
+
+        return new float[]{allocA, allocB};
+    };
+
+    @Override
+    public void remove() {
+        if (!level.isClientSide) {
+            removeSink(inputSink, lastInputNetwork);
+            removeSink(controlSink, lastControlNetwork);
+        }
+        super.remove();
+    };
+
+    @Override
+    public void onChunkUnloaded() {
+        if (!level.isClientSide) {
+            removeSink(inputSink, lastInputNetwork);
+            removeSink(controlSink, lastControlNetwork);
+        }
+        super.onChunkUnloaded();
     };
 
     @Override
     public void onSpeedChanged(float previousSpeed) {
         super.onSpeedChanged(previousSpeed);
-        if (speed == 0f || advancementBehaviour.getPlayer() == null) return;
-        Direction direction = DirectionalRotatedPillarKineticBlock.getDirection(getBlockState());
-        BlockPos otherAdjacentPos = getBlockPos().relative(direction.getOpposite());
-        if (propagatesToMe(otherAdjacentPos, direction) && getLevel().getBlockEntity(otherAdjacentPos) instanceof KineticBlockEntity kbe) {
-            if (kbe.getSpeed() != 0f) advancementBehaviour.awardAdvancement(PetrolsPartsAdvancementTriggers.DIFFERENTIAL);
-        };
-    };
-
-    @Override
-    @SuppressWarnings("null")
-    public void removeSource() {
-        super.removeSource();
-        if (hasLevel()) getLevel().setBlockAndUpdate(getBlockPos(), getBlockState().cycle(DirectionalRotatedPillarKineticBlock.POSITIVE_AXIS_DIRECTION));
-    };
-
-    @SuppressWarnings("null")
-    public float ratio(BlockState stateFrom) {
-        Direction towardsInput = DirectionalRotatedPillarKineticBlock.getDirection(stateFrom);
-        Direction towardsControl = towardsInput.getOpposite();
-        BlockPos inputPos = getBlockPos().relative(towardsInput);
-        BlockPos controlPos = getBlockPos().relative(towardsControl);
-
-        BlockEntity inputBE = getLevel().getBlockEntity(inputPos);
-        float inputSpeed = 0f;
-        if (propagatesToMe(inputPos, towardsControl) && inputBE instanceof KineticBlockEntity inputKBE) inputSpeed = getPropagatedSpeed(inputKBE, towardsControl);
-
-        BlockEntity controlBE = getLevel().getBlockEntity(controlPos);
-        float controlSpeed = 0f;
-        if (propagatesToMe(controlPos, towardsInput) && controlBE instanceof KineticBlockEntity controlKBE) controlSpeed = getPropagatedSpeed(controlKBE, towardsInput);
-
-        if (inputSpeed + controlSpeed == 0f) return 0f;
-        return 2f * inputSpeed / (inputSpeed + controlSpeed);
+        if (speed == 0f || advancementBehaviour == null || advancementBehaviour.getPlayer() == null) return;
+        Direction face = DirectionalRotatedPillarKineticBlock.getDirection(getBlockState());
+        boolean sideAActive = getAdjacentKBE(getBlockPos().relative(face), face.getOpposite()) != null;
+        boolean sideBActive = getAdjacentKBE(getBlockPos().relative(face.getOpposite()), face) != null;
+        if (sideAActive && sideBActive) advancementBehaviour.awardAdvancement(PetrolsPartsAdvancementTriggers.DIFFERENTIAL);
     };
 
     @SuppressWarnings("null")
@@ -125,29 +270,25 @@ public class DifferentialBlockEntity extends SplitShaftBlockEntity {
 
     public float getPropagatedSpeed(KineticBlockEntity from, Direction directionToMe) {
         if (from instanceof DifferentialBlockEntity) return 0f;
-        return from.getSpeed() * RotationPropagatorAccessor.invokeGetAxisModifier(from, directionToMe);
+
+        return from.getSpeed() * com.petrolpark.petrolsparts.mixin.accessor.RotationPropagatorAccessor.invokeGetAxisModifier(from, directionToMe);
     };
 
     @Override
-	public List<BlockPos> addPropagationLocations(IRotate block, BlockState state, List<BlockPos> neighbours) {
-	    super.addPropagationLocations(block, state, neighbours);
-		KineticsHelper.addLargeCogwheelPropagationLocations(worldPosition, neighbours);
-		return neighbours;
-	};
+    public List<BlockPos> addPropagationLocations(IRotate block, BlockState state, List<BlockPos> neighbours) {
+        super.addPropagationLocations(block, state, neighbours);
+        KineticsHelper.addLargeCogwheelPropagationLocations(worldPosition, neighbours);
+        return neighbours;
+    };
 
     @Override
     protected boolean canPropagateDiagonally(IRotate block, BlockState state) {
-		return true;
-	};
-
-    @Override
-    public float getRotationSpeedModifier(Direction face) {
-        return ratio(getBlockState());
+        return true;
     };
 
     @Override
     protected AABB createRenderBoundingBox() {
         return new AABB(worldPosition).inflate(1);
     };
-    
+
 };

--- a/src/main/java/com/petrolpark/petrolsparts/content/kinetics/differential/DifferentialBlockEntity.java
+++ b/src/main/java/com/petrolpark/petrolsparts/content/kinetics/differential/DifferentialBlockEntity.java
@@ -31,6 +31,11 @@ public class DifferentialBlockEntity extends GeneratingKineticBlockEntity {
     private DifferentialSink controlSink;
     private Long lastInputNetwork = null;
     private Long lastControlNetwork = null;
+    // Last observed non-zero speed per side. Used as fallback for the proportional stress
+    // split when a side is stopped due to overstress (kbeA still connected but getSpeed()=0).
+    // Reset to 0 when the side is genuinely disconnected (removeSink fires on network change).
+    private float lastNonZeroAbsA = 0f;
+    private float lastNonZeroAbsB = 0f;
 
     public DifferentialBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -62,8 +67,14 @@ public class DifferentialBlockEntity extends GeneratingKineticBlockEntity {
         float absA = kbeA != null ? Math.abs(getPropagatedSpeed(kbeA, face.getOpposite())) : 0f;
         float absB = kbeB != null ? Math.abs(getPropagatedSpeed(kbeB, face)) : 0f;
 
-        float capacityA = absA > 0f ? getNetworkCapacity(inputSink, lastInputNetwork) : 0f;
-        float capacityB = absB > 0f
+        // Use effective speed: if a side is overstress-stopped (connected but speed=0),
+        // it still contributes capacity — its network is still live, just halted.
+        // If genuinely disconnected (kbe==null), it contributes nothing.
+        boolean aLive = absA > 0f || (kbeA != null && lastInputNetwork   != null);
+        boolean bLive = absB > 0f || (kbeB != null && lastControlNetwork != null);
+
+        float capacityA = aLive ? getNetworkCapacity(inputSink, lastInputNetwork) : 0f;
+        float capacityB = bLive
                 ? (Objects.equals(lastInputNetwork, lastControlNetwork) ? 0f : getNetworkCapacity(controlSink, lastControlNetwork))
                 : 0f;
         float coefficient = (capacityA + capacityB) / Math.abs(speed);
@@ -135,11 +146,13 @@ public class DifferentialBlockEntity extends GeneratingKineticBlockEntity {
             removeSink(inputSink, lastInputNetwork);
             injectSink(inputSink, netA);
             lastInputNetwork = netA;
+            if (netA == null) lastNonZeroAbsA = 0f; // genuinely disconnected — forget last speed
         }
         if (!Objects.equals(netB, lastControlNetwork)) {
             removeSink(controlSink, lastControlNetwork);
             injectSink(controlSink, netB);
             lastControlNetwork = netB;
+            if (netB == null) lastNonZeroAbsB = 0f; // genuinely disconnected — forget last speed
         }
 
         // Proportional split with capacity-aware redistribution:
@@ -149,11 +162,25 @@ public class DifferentialBlockEntity extends GeneratingKineticBlockEntity {
         // demand, both become overstressed
         float absA = kbeA != null ? Math.abs(getPropagatedSpeed(kbeA, face.getOpposite())) : 0f;
         float absB = kbeB != null ? Math.abs(getPropagatedSpeed(kbeB, face)) : 0f;
-        float totalAbs = absA + absB;
+
+        // Update last-known non-zero speeds. When a network is overstressed, all its KBEs
+        // report speed=0 even though the motor is still physically connected. We use the
+        // last non-zero speed to keep the proportional split meaningful in that state.
+        if (absA > 0f) lastNonZeroAbsA = absA;
+        if (absB > 0f) lastNonZeroAbsB = absB;
+
+        // Effective speeds for splitting:
+        // - If abs>0: use it directly (normal operation, or input running while output stopped)
+        // - If abs=0 but still connected (kbe!=null, network registered): use lastNonZero
+        //   This is the overstress case — the motor is trying to run but the network stopped
+        // - If abs=0 and disconnected (kbe==null): use 0 (clutch/removed motor — no contribution)
+        float effA = absA > 0f ? absA : (kbeA != null && lastInputNetwork   != null ? lastNonZeroAbsA : 0f);
+        float effB = absB > 0f ? absB : (kbeB != null && lastControlNetwork != null ? lastNonZeroAbsB : 0f);
+        float totalEff = effA + effB;
         float totalDemand = this.stress;
 
-        float requestedA = totalAbs > 0f ? totalDemand * (absA / totalAbs) : totalDemand * 0.5f;
-        float requestedB = totalAbs > 0f ? totalDemand * (absB / totalAbs) : totalDemand * 0.5f;
+        float requestedA = totalEff > 0f ? totalDemand * (effA / totalEff) : totalDemand * 0.5f;
+        float requestedB = totalEff > 0f ? totalDemand * (effB / totalEff) : totalDemand * 0.5f;
 
         // Available headroom on each input network.
         float capacityA = absA > 0f ? getNetworkCapacity(inputSink, lastInputNetwork) : 0f;
@@ -162,8 +189,8 @@ public class DifferentialBlockEntity extends GeneratingKineticBlockEntity {
         float stressB   = absB > 0f ? getNetworkStress(controlSink, lastControlNetwork)   : 0f;
         float sinkOwnDrawA = inputSink  != null ? inputSink.getStressImpact()  : 0f;
         float sinkOwnDrawB = controlSink != null ? controlSink.getStressImpact() : 0f;
-        float headroomA = absA > 0f ? Math.max(0f, capacityA - (stressA - sinkOwnDrawA)) : 0f;
-        float headroomB = absB > 0f ? Math.max(0f, capacityB - (stressB - sinkOwnDrawB)) : 0f;
+        float headroomA = Math.max(0f, capacityA - (stressA - sinkOwnDrawA));
+        float headroomB = Math.max(0f, capacityB - (stressB - sinkOwnDrawB));
 
         float allocA = distributeStress(requestedA, requestedB, headroomA, headroomB)[0];
         float allocB = distributeStress(requestedA, requestedB, headroomA, headroomB)[1];
@@ -211,6 +238,27 @@ public class DifferentialBlockEntity extends GeneratingKineticBlockEntity {
     };
 
     private float[] distributeStress(float requestedA, float requestedB, float headroomA, float headroomB) {
+        float totalDemand    = requestedA + requestedB;
+        float totalHeadroom  = headroomA  + headroomB;
+
+        if (totalDemand > totalHeadroom) {
+            // Stage 3: combined capacity is insufficient.
+            // Give each side its full headroom plus its proportional share of the excess.
+            // This ensures both networks overstress symmetrically rather than one absorbing all overflow.
+            float excess = totalDemand - totalHeadroom;
+            float totalReq = requestedA + requestedB; // == totalDemand, kept for clarity
+            float shareA = totalReq > 0f ? requestedA / totalReq : 0.5f;
+            float shareB = totalReq > 0f ? requestedB / totalReq : 0.5f;
+            float allocA = headroomA + excess * shareA;
+            float allocB = headroomB + excess * shareB;
+            PetrolsParts.LOGGER.debug(
+                "[Differential {}] distributeStress STAGE3: excess={} shareA={} shareB={} → allocA={} allocB={}",
+                worldPosition, excess, shareA, shareB, allocA, allocB
+            );
+            return new float[]{allocA, allocB};
+        }
+
+        // Stages 1 & 2: combined capacity is sufficient — redistribute from saturated to unsaturated.
         float allocA = requestedA;
         float allocB = requestedB;
 

--- a/src/main/java/com/petrolpark/petrolsparts/content/kinetics/differential/DifferentialSink.java
+++ b/src/main/java/com/petrolpark/petrolsparts/content/kinetics/differential/DifferentialSink.java
@@ -1,0 +1,38 @@
+package com.petrolpark.petrolsparts.content.kinetics.differential;
+
+import com.petrolpark.petrolsparts.PetrolsPartsBlockEntityTypes;
+import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+
+public class DifferentialSink extends KineticBlockEntity {
+
+    public DifferentialSink(DifferentialBlockEntity owner) {
+        super(PetrolsPartsBlockEntityTypes.DIFFERENTIAL.get(), owner.getBlockPos(), owner.getBlockState());
+        this.level = owner.getLevel();
+    }
+
+    // getActualStressOf(sink) = members.get(sink) * |getTheoreticalSpeed()| = lastStressApplied * 1f
+    @Override public float getTheoreticalSpeed() { return 1f; }
+    @Override public float getGeneratedSpeed() { return 0f; }
+    @Override public float calculateStressApplied() { return lastStressApplied; }
+
+    public void setStressImpact(float impact) { lastStressApplied = impact; }
+    public float getStressImpact() { return lastStressApplied; }
+
+    public float lastNetworkCapacity = 0f;
+    public float lastNetworkStress = 0f;
+
+    @Override
+    public void updateFromNetwork(float maxStress, float currentStress, int networkSize) {
+        lastNetworkCapacity = maxStress;
+        lastNetworkStress = currentStress;
+    }
+    @Override public void setChanged() {}
+    @Override public void tick() {}
+    @Override public void initialize() {}
+    @Override public void remove() {}
+    @Override protected void write(CompoundTag tag, HolderLookup.Provider r, boolean c) {}
+    @Override protected void read(CompoundTag tag, HolderLookup.Provider r, boolean c) {}
+};

--- a/src/main/java/com/petrolpark/petrolsparts/mixin/KineticNetworkMixin.java
+++ b/src/main/java/com/petrolpark/petrolsparts/mixin/KineticNetworkMixin.java
@@ -1,0 +1,47 @@
+package com.petrolpark.petrolsparts.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.petrolpark.petrolsparts.content.kinetics.differential.DifferentialSink;
+import com.simibubi.create.content.kinetics.KineticNetwork;
+import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+@Mixin(KineticNetwork.class)
+public class KineticNetworkMixin {
+
+    // KineticNetwork.calculateStress() evicts any KBE where level.getBlockEntity(pos) != be.
+    // DifferentialSink is not in the world, so it always fails this check.
+    // Return `be` itself when it's a DifferentialSink so the identity check passes (be == be).
+
+    @WrapOperation(
+        method = "calculateStress",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getBlockEntity(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/entity/BlockEntity;"),
+        remap = false
+    )
+    private BlockEntity wrapGetBlockEntityCalculateStress(
+            Level level, BlockPos pos, Operation<BlockEntity> original,
+            @Local KineticBlockEntity be) {
+        if (be instanceof DifferentialSink) return be;
+        return original.call(level, pos);
+    }
+
+    @WrapOperation(
+        method = "calculateCapacity",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getBlockEntity(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/entity/BlockEntity;"),
+        remap = false
+    )
+    private BlockEntity wrapGetBlockEntityCalculateCapacity(
+            Level level, BlockPos pos, Operation<BlockEntity> original,
+            @Local KineticBlockEntity be) {
+        if (be instanceof DifferentialSink) return be;
+        return original.call(level, pos);
+    }
+};

--- a/src/main/java/com/petrolpark/petrolsparts/mixin/accessor/KineticNetworkAccessor.java
+++ b/src/main/java/com/petrolpark/petrolsparts/mixin/accessor/KineticNetworkAccessor.java
@@ -1,0 +1,16 @@
+package com.petrolpark.petrolsparts.mixin.accessor;
+
+import com.simibubi.create.content.kinetics.KineticNetwork;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(KineticNetwork.class)
+public interface KineticNetworkAccessor {
+
+    @Accessor("currentCapacity")
+    float getCurrentCapacity();
+
+    @Accessor("currentStress")
+    float getCurrentStress();
+
+}

--- a/src/main/resources/petrolsparts.mixins.json
+++ b/src/main/resources/petrolsparts.mixins.json
@@ -6,10 +6,12 @@
     "plugin": "com.petrolpark.petrolsparts.mixin.plugin.PetrolsPartsMixinPlugin",
     "mixins": [
         "accessor.DeployerRecipeSearchEventAccessor",
+        "accessor.KineticNetworkAccessor",
         "accessor.RotationPropagatorAccessor",
         "AirCurrentMixin",
         "AssemblyOperatorBlockItemMixin",
         "KineticBlockEntityMixin",
+        "KineticNetworkMixin",
         "MechanicalPressBlockEntityMixin",
         "RotationPropagatorMixin",
         "SpoutBlockEntityMixin"


### PR DESCRIPTION
## Summary

  Differential rework: transformed from asymmetric SplitShaftBlockEntity to symmetric GeneratingKineticBlockEntity. Both input shafts now act as true power inputs; ring gear output generated from average speed of inputs.

**Key Changes:**

  - Redesigned as kinetic generator with phantom stress sinks (DifferentialSink) injected into both input networks
  - Output speed = (speedA + speedB) / 2; output stress split between inputs proportional to their speed contribution
  - Redistribution: if one input network at capacity, excess shifted to other side; if both full, both overstress
  - Added KineticNetworkMixin to bypass identity-check eviction for DifferentialSink (unregistered world phantom object)
  - Tracks last non-zero speeds per side to handle overstressed motors: network halted but motor still connected gets proportional stress allocation
  - Lifecycle: sinks injected on network detection, removed on disconnection or chunk unload

  **Architecture:**
```
  Input A [network] ←─── [inputSink] ──┐
                                        [DifferentialBlockEntity: generator] → [output ring gear network]
  Input B [network] ←─── [controlSink] ┘
```

  **Testing:** Place differential between two motors + load consumer. Verify both motors drain stress proportionally. Remove one motor → other carries full load at half output speed.
  Overstress output → both inputs overstress symmetrically.
  
  This rewrite effectively addresses issues #71 and #104.
  
  There is a persisting issue with Overstress flicker that I will work to solve. If this comes though, the asymetric nature of the current differential implementation can be dropped meaning the ponder info and the model might need an update.