### PR TITLE
Fix JSON formatting in ja_jp.json

### DIFF
--- a/src/main/resources/assets/petrolsparts/lang/ja_jp.json
+++ b/src/main/resources/assets/petrolsparts/lang/ja_jp.json
@@ -2,7 +2,7 @@
     "advancement.petrolsparts.bevel_cogwheel": "傘の新発見",
     "advancement.petrolsparts.bevel_cogwheel.description": "かさ歯車を使って、回転の向きを直角に変える",
     "advancement.petrolsparts.bevel_cogwheel_ball": "球の中の歯車",
-    "advancement.petrolsparts.bevel_cogwheel_ball.description": "歯車とかさ歯車を組み合わせて、歯車球を作る"
+    "advancement.petrolsparts.bevel_cogwheel_ball.description": "歯車とかさ歯車を組み合わせて、歯車球を作る",
     "advancement.petrolsparts.coaxial_gear": "針の穴を通す",
     "advancement.petrolsparts.coaxial_gear.description": "同軸歯車を、そこを通るシャフトとは異なる速度で回転させる",
     "advancement.petrolsparts.colossal_cogwheel_power_many": "歯車のゴッドファーザー",


### PR DESCRIPTION
I accidentally left out a comma in ja_jp.json, which caused a syntax error preventing the language file from loading properly.
(Sorry for the oversight in my previous PR...)